### PR TITLE
Fix Seq2Seq training args

### DIFF
--- a/train/train_ce.py
+++ b/train/train_ce.py
@@ -67,7 +67,7 @@ def main():
         warmup_steps=200,                   # Warmup for stability
         label_smoothing_factor=0.1,         # Label smoothing
         fp16=True,                          # Mixed precision
-        evaluation_strategy="epoch",
+        eval_strategy="epoch",
         save_strategy="epoch",              # Save each epoch
         save_total_limit=1,                 # Keep only best checkpoint
         report_to="none",                   # Disable wandb/tensorboard


### PR DESCRIPTION
## Summary
- update transformer argument name

## Testing
- `python test_loader.py` *(fails: Couldn't reach 'CADCODER/GenCAD-Code' on the Hub)*
- `python test_pipeline.py` *(fails: Couldn't reach 'CADCODER/GenCAD-Code' on the Hub)*

------
https://chatgpt.com/codex/tasks/task_e_68605ea97da48327a2954de3c4a397be